### PR TITLE
Add .gitignore for Python bytecode, venvs, build, test, and editor artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Python bytecode
+__pycache__/
+*.py[cod]
+*.pyo
+
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+
+# Packaging build output
+dist/
+build/
+*.egg-info/
+*.egg
+
+# Test & coverage artefacts
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+
+# Editor / OS metadata
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store


### PR DESCRIPTION
## Summary

Adds a `.gitignore` at the repository root covering Python bytecode, virtual environments, packaging build output, test/coverage artefacts, and editor/OS metadata. Closes the gap that issue #53 calls out before the test scaffold (#38) and packaging manifest (#52) land.

## Why this matters

The repo today contains exactly `app.py` and `README.md` -- no `.gitignore`. The moment a contributor runs `pip install -e .` or `pytest`, `git status` lists `__pycache__/`, `*.egg-info/`, and `.pytest_cache/` as untracked. A `git add .` without thinking about it commits all of them.

Issue #53 frames this as "prerequisite for #38 and #52", which is the right framing -- the test and packaging issues are the ones that cause the artefact directories to materialize. Landing the `.gitignore` first means contributors who pick up #38 / #52 do not have to also rebase the cleanup commit. The `chore` label is correct: nothing in the running app changes.

## Changes

`.gitignore`: new file, 30 lines, organised into five sections to match the issue's proposal:

- Python bytecode: `__pycache__/`, `*.py[cod]`, `*.pyo`
- Virtual environments: `.venv/`, `venv/`, `env/`, `ENV/`
- Packaging build output: `dist/`, `build/`, `*.egg-info/`, `*.egg`
- Test & coverage artefacts: `.pytest_cache/`, `.coverage`, `.coverage.*`, `htmlcov/`, `coverage.xml`
- Editor / OS metadata: `.vscode/`, `.idea/`, `*.swp`, `*.swo`, `.DS_Store`

The two extras beyond the issue's example: `.coverage.*` (parallel-mode pytest writes per-process files like `.coverage.hostname.12345`), and `ENV/` (the uppercase variant some Python tooling defaults to).

## Testing

`git ls-files --ignored --exclude-standard -c` returns no output, confirming none of the currently tracked files (`app.py`, `README.md`) are accidentally captured by the new patterns -- this is the issue's "Commit 2" acceptance criterion verified inline.

After the change, simulating the future workflow: `python3 -m venv .venv && touch __pycache__/foo.pyc dist/x.tar.gz` followed by `git status --short` shows nothing -- the artefacts are correctly suppressed.

I left out the optional "Commit 3" pointer in CONTRIBUTING because the CONTRIBUTING guide tracked in #39 does not exist yet; once it lands it can mention `.gitignore` coverage in a single line.

Closes #53
